### PR TITLE
Adding vm-browserify 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 package-lock.json
 pnpm-lock.yaml
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "stream-http": "^3.2.0",
     "style-loader": "^3.3.4",
     "url": "^0.11.3",
+    "vm-browserify": "^1.1.2",
     "webpack": "^5.90.3",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.2"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,7 @@ module.exports = {
   },
   resolve: {
     fallback: {
+      vm: require.resolve("vm-browserify"),
       https: require.resolve("https-browserify"),
       http: require.resolve("stream-http"),
       crypto: require.resolve("crypto-browserify"),


### PR DESCRIPTION
It seems webpack5 needs to have this polyfill in place to avoid a compilation error with asn1, so I'm adding to devdependencies and webpack config files. 

I also added yarn.lock to .gitignore. 