### PR TITLE
add issue transfer to docs project

### DIFF
--- a/.github/issue-transfer.yml
+++ b/.github/issue-transfer.yml
@@ -1,0 +1,46 @@
+name: Transfer New Issue to Docs Project
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  transfer:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Transfer Issue
+      uses: actions/github-script@v5
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: script: |
+  const issueTitle = context.payload.issue.title;
+  const issueBody = context.payload.issue.body;
+  const issueNumber = context.payload.issue.number;
+  const organizationName = 'near';
+  const projectName = 'NEAR Docs';
+
+  // Fetch project ID and other necessary IDs
+  const query = `
+    query {
+      organization(login: "${organization\$rg}") {
+        projectV2(number: 117) {
+          id
+        }
+      }
+    }
+  `;
+
+  const projectId = await github.graphql(query);
+
+  // Add issue to the project
+  const mutation = `
+    mutation($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+        item {
+          id
+        }
+      }
+    }
+  `;
+
+  await github.graphql(mutation, { projectId: projectId.organization.projectV2.id, contentId: context.payload.issue.node_id });


### PR DESCRIPTION
Adds workflow that will add issues created in this repository to an external org (/near) project tracker (#117 Docs)